### PR TITLE
fix: Fix test_import_all warnings by using @case package prefix

### DIFF
--- a/src/alternating_case_test.mbt
+++ b/src/alternating_case_test.mbt
@@ -1,22 +1,22 @@
 ///|
 test "alternating_case basic conversion" {
-  assert_eq(alternating_case("hello"), "hElLo")
-  assert_eq(alternating_case("hello world"), "hElLo WoRlD")
-  assert_eq(alternating_case("test123"), "tEsT123")
+  assert_eq(@case.alternating_case("hello"), "hElLo")
+  assert_eq(@case.alternating_case("hello world"), "hElLo WoRlD")
+  assert_eq(@case.alternating_case("test123"), "tEsT123")
 }
 
 ///|
 test "alternating_case edge cases" {
-  assert_eq(alternating_case(""), "")
-  assert_eq(alternating_case("123"), "123")
-  assert_eq(alternating_case("!@#"), "!@#")
-  assert_eq(alternating_case("a"), "a")
-  assert_eq(alternating_case("ab"), "aB")
+  assert_eq(@case.alternating_case(""), "")
+  assert_eq(@case.alternating_case("123"), "123")
+  assert_eq(@case.alternating_case("!@#"), "!@#")
+  assert_eq(@case.alternating_case("a"), "a")
+  assert_eq(@case.alternating_case("ab"), "aB")
 }
 
 ///|
 test "alternating_case with symbols" {
-  assert_eq(alternating_case("a-b-c"), "a-B-c")
-  assert_eq(alternating_case("test_case"), "tEsT_cAsE")
-  assert_eq(alternating_case("hello123world"), "hElLo123WoRlD")
+  assert_eq(@case.alternating_case("a-b-c"), "a-B-c")
+  assert_eq(@case.alternating_case("test_case"), "tEsT_cAsE")
+  assert_eq(@case.alternating_case("hello123world"), "hElLo123WoRlD")
 }

--- a/src/camel_case_test.mbt
+++ b/src/camel_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "camel_case basic conversion" {
-  assert_eq(camel_case("hello world"), "helloWorld")
-  assert_eq(camel_case("Hello-World"), "helloWorld")
-  assert_eq(camel_case("HELLO_WORLD"), "helloWorld")
-  assert_eq(camel_case("hello"), "hello")
+  assert_eq(@case.camel_case("hello world"), "helloWorld")
+  assert_eq(@case.camel_case("Hello-World"), "helloWorld")
+  assert_eq(@case.camel_case("HELLO_WORLD"), "helloWorld")
+  assert_eq(@case.camel_case("hello"), "hello")
 }
 
 ///|
 test "camel_case edge cases" {
-  assert_eq(camel_case(""), "")
-  assert_eq(camel_case("a"), "a")
-  assert_eq(camel_case("A"), "a")
-  assert_eq(camel_case("123"), "123")
+  assert_eq(@case.camel_case(""), "")
+  assert_eq(@case.camel_case("a"), "a")
+  assert_eq(@case.camel_case("A"), "a")
+  assert_eq(@case.camel_case("123"), "123")
 }
 
 ///|
 test "camel_case complex cases" {
-  assert_eq(camel_case("XMLHttpRequest"), "xmlHttpRequest")
-  assert_eq(camel_case("iPhone-App"), "iPhoneApp")
-  assert_eq(camel_case("foo_bar_baz"), "fooBarBaz")
-  assert_eq(camel_case("test123value"), "test123Value")
+  assert_eq(@case.camel_case("XMLHttpRequest"), "xmlHttpRequest")
+  assert_eq(@case.camel_case("iPhone-App"), "iPhoneApp")
+  assert_eq(@case.camel_case("foo_bar_baz"), "fooBarBaz")
+  assert_eq(@case.camel_case("test123value"), "test123Value")
 }

--- a/src/capital_case_test.mbt
+++ b/src/capital_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "capital_case basic conversion" {
-  assert_eq(capital_case("hello world"), "Hello World")
-  assert_eq(capital_case("HelloWorld"), "Hello World")
-  assert_eq(capital_case("hello_world"), "Hello World")
-  assert_eq(capital_case("hello"), "Hello")
+  assert_eq(@case.capital_case("hello world"), "Hello World")
+  assert_eq(@case.capital_case("HelloWorld"), "Hello World")
+  assert_eq(@case.capital_case("hello_world"), "Hello World")
+  assert_eq(@case.capital_case("hello"), "Hello")
 }
 
 ///|
 test "capital_case edge cases" {
-  assert_eq(capital_case(""), "")
-  assert_eq(capital_case("a"), "A")
-  assert_eq(capital_case("A"), "A")
-  assert_eq(capital_case("123"), "123")
+  assert_eq(@case.capital_case(""), "")
+  assert_eq(@case.capital_case("a"), "A")
+  assert_eq(@case.capital_case("A"), "A")
+  assert_eq(@case.capital_case("123"), "123")
 }
 
 ///|
 test "capital_case complex cases" {
-  assert_eq(capital_case("XMLHttpRequest"), "Xml Http Request")
-  assert_eq(capital_case("iPhone-App"), "I Phone App")
-  assert_eq(capital_case("foo bar baz"), "Foo Bar Baz")
-  assert_eq(capital_case("test123value"), "Test 123 Value")
+  assert_eq(@case.capital_case("XMLHttpRequest"), "Xml Http Request")
+  assert_eq(@case.capital_case("iPhone-App"), "I Phone App")
+  assert_eq(@case.capital_case("foo bar baz"), "Foo Bar Baz")
+  assert_eq(@case.capital_case("test123value"), "Test 123 Value")
 }

--- a/src/constant_case_test.mbt
+++ b/src/constant_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "constant_case basic conversion" {
-  assert_eq(constant_case("hello world"), "HELLO_WORLD")
-  assert_eq(constant_case("HelloWorld"), "HELLO_WORLD")
-  assert_eq(constant_case("hello-world"), "HELLO_WORLD")
-  assert_eq(constant_case("hello"), "HELLO")
+  assert_eq(@case.constant_case("hello world"), "HELLO_WORLD")
+  assert_eq(@case.constant_case("HelloWorld"), "HELLO_WORLD")
+  assert_eq(@case.constant_case("hello-world"), "HELLO_WORLD")
+  assert_eq(@case.constant_case("hello"), "HELLO")
 }
 
 ///|
 test "constant_case edge cases" {
-  assert_eq(constant_case(""), "")
-  assert_eq(constant_case("a"), "A")
-  assert_eq(constant_case("A"), "A")
-  assert_eq(constant_case("123"), "123")
+  assert_eq(@case.constant_case(""), "")
+  assert_eq(@case.constant_case("a"), "A")
+  assert_eq(@case.constant_case("A"), "A")
+  assert_eq(@case.constant_case("123"), "123")
 }
 
 ///|
 test "constant_case complex cases" {
-  assert_eq(constant_case("XMLHttpRequest"), "XML_HTTP_REQUEST")
-  assert_eq(constant_case("iPhone-App"), "I_PHONE_APP")
-  assert_eq(constant_case("foo bar baz"), "FOO_BAR_BAZ")
-  assert_eq(constant_case("test123value"), "TEST_123_VALUE")
+  assert_eq(@case.constant_case("XMLHttpRequest"), "XML_HTTP_REQUEST")
+  assert_eq(@case.constant_case("iPhone-App"), "I_PHONE_APP")
+  assert_eq(@case.constant_case("foo bar baz"), "FOO_BAR_BAZ")
+  assert_eq(@case.constant_case("test123value"), "TEST_123_VALUE")
 }

--- a/src/dot_case_test.mbt
+++ b/src/dot_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "dot_case basic conversion" {
-  assert_eq(dot_case("hello world"), "hello.world")
-  assert_eq(dot_case("HelloWorld"), "hello.world")
-  assert_eq(dot_case("hello_world"), "hello.world")
-  assert_eq(dot_case("hello"), "hello")
+  assert_eq(@case.dot_case("hello world"), "hello.world")
+  assert_eq(@case.dot_case("HelloWorld"), "hello.world")
+  assert_eq(@case.dot_case("hello_world"), "hello.world")
+  assert_eq(@case.dot_case("hello"), "hello")
 }
 
 ///|
 test "dot_case edge cases" {
-  assert_eq(dot_case(""), "")
-  assert_eq(dot_case("a"), "a")
-  assert_eq(dot_case("A"), "a")
-  assert_eq(dot_case("123"), "123")
+  assert_eq(@case.dot_case(""), "")
+  assert_eq(@case.dot_case("a"), "a")
+  assert_eq(@case.dot_case("A"), "a")
+  assert_eq(@case.dot_case("123"), "123")
 }
 
 ///|
 test "dot_case complex cases" {
-  assert_eq(dot_case("XMLHttpRequest"), "xml.http.request")
-  assert_eq(dot_case("iPhone-App"), "i.phone.app")
-  assert_eq(dot_case("foo bar baz"), "foo.bar.baz")
-  assert_eq(dot_case("test123value"), "test.123.value")
+  assert_eq(@case.dot_case("XMLHttpRequest"), "xml.http.request")
+  assert_eq(@case.dot_case("iPhone-App"), "i.phone.app")
+  assert_eq(@case.dot_case("foo bar baz"), "foo.bar.baz")
+  assert_eq(@case.dot_case("test123value"), "test.123.value")
 }

--- a/src/kebab_case_test.mbt
+++ b/src/kebab_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "kebab_case basic conversion" {
-  assert_eq(kebab_case("hello world"), "hello-world")
-  assert_eq(kebab_case("HelloWorld"), "hello-world")
-  assert_eq(kebab_case("hello_world"), "hello-world")
-  assert_eq(kebab_case("hello"), "hello")
+  assert_eq(@case.kebab_case("hello world"), "hello-world")
+  assert_eq(@case.kebab_case("HelloWorld"), "hello-world")
+  assert_eq(@case.kebab_case("hello_world"), "hello-world")
+  assert_eq(@case.kebab_case("hello"), "hello")
 }
 
 ///|
 test "kebab_case edge cases" {
-  assert_eq(kebab_case(""), "")
-  assert_eq(kebab_case("a"), "a")
-  assert_eq(kebab_case("A"), "a")
-  assert_eq(kebab_case("123"), "123")
+  assert_eq(@case.kebab_case(""), "")
+  assert_eq(@case.kebab_case("a"), "a")
+  assert_eq(@case.kebab_case("A"), "a")
+  assert_eq(@case.kebab_case("123"), "123")
 }
 
 ///|
 test "kebab_case complex cases" {
-  assert_eq(kebab_case("XMLHttpRequest"), "xml-http-request")
-  assert_eq(kebab_case("iPhone-App"), "i-phone-app")
-  assert_eq(kebab_case("foo bar baz"), "foo-bar-baz")
-  assert_eq(kebab_case("test123value"), "test-123-value")
+  assert_eq(@case.kebab_case("XMLHttpRequest"), "xml-http-request")
+  assert_eq(@case.kebab_case("iPhone-App"), "i-phone-app")
+  assert_eq(@case.kebab_case("foo bar baz"), "foo-bar-baz")
+  assert_eq(@case.kebab_case("test123value"), "test-123-value")
 }

--- a/src/no_case_test.mbt
+++ b/src/no_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "no_case basic conversion" {
-  assert_eq(no_case("hello world"), "hello world")
-  assert_eq(no_case("HelloWorld"), "hello world")
-  assert_eq(no_case("hello_world"), "hello world")
-  assert_eq(no_case("hello"), "hello")
+  assert_eq(@case.no_case("hello world"), "hello world")
+  assert_eq(@case.no_case("HelloWorld"), "hello world")
+  assert_eq(@case.no_case("hello_world"), "hello world")
+  assert_eq(@case.no_case("hello"), "hello")
 }
 
 ///|
 test "no_case edge cases" {
-  assert_eq(no_case(""), "")
-  assert_eq(no_case("a"), "a")
-  assert_eq(no_case("A"), "a")
-  assert_eq(no_case("123"), "123")
+  assert_eq(@case.no_case(""), "")
+  assert_eq(@case.no_case("a"), "a")
+  assert_eq(@case.no_case("A"), "a")
+  assert_eq(@case.no_case("123"), "123")
 }
 
 ///|
 test "no_case complex cases" {
-  assert_eq(no_case("XMLHttpRequest"), "xml http request")
-  assert_eq(no_case("iPhone-App"), "i phone app")
-  assert_eq(no_case("foo bar baz"), "foo bar baz")
-  assert_eq(no_case("test123value"), "test 123 value")
+  assert_eq(@case.no_case("XMLHttpRequest"), "xml http request")
+  assert_eq(@case.no_case("iPhone-App"), "i phone app")
+  assert_eq(@case.no_case("foo bar baz"), "foo bar baz")
+  assert_eq(@case.no_case("test123value"), "test 123 value")
 }

--- a/src/pascal_case_test.mbt
+++ b/src/pascal_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "pascal_case basic conversion" {
-  assert_eq(pascal_case("hello world"), "HelloWorld")
-  assert_eq(pascal_case("hello-world"), "HelloWorld")
-  assert_eq(pascal_case("HELLO_WORLD"), "HelloWorld")
-  assert_eq(pascal_case("hello"), "Hello")
+  assert_eq(@case.pascal_case("hello world"), "HelloWorld")
+  assert_eq(@case.pascal_case("hello-world"), "HelloWorld")
+  assert_eq(@case.pascal_case("HELLO_WORLD"), "HelloWorld")
+  assert_eq(@case.pascal_case("hello"), "Hello")
 }
 
 ///|
 test "pascal_case edge cases" {
-  assert_eq(pascal_case(""), "")
-  assert_eq(pascal_case("a"), "A")
-  assert_eq(pascal_case("A"), "A")
-  assert_eq(pascal_case("123"), "123")
+  assert_eq(@case.pascal_case(""), "")
+  assert_eq(@case.pascal_case("a"), "A")
+  assert_eq(@case.pascal_case("A"), "A")
+  assert_eq(@case.pascal_case("123"), "123")
 }
 
 ///|
 test "pascal_case complex cases" {
-  assert_eq(pascal_case("XMLHttpRequest"), "XmlHttpRequest")
-  assert_eq(pascal_case("iPhone-app"), "IPhoneApp")
-  assert_eq(pascal_case("foo_bar_baz"), "FooBarBaz")
-  assert_eq(pascal_case("test123value"), "Test123Value")
+  assert_eq(@case.pascal_case("XMLHttpRequest"), "XmlHttpRequest")
+  assert_eq(@case.pascal_case("iPhone-app"), "IPhoneApp")
+  assert_eq(@case.pascal_case("foo_bar_baz"), "FooBarBaz")
+  assert_eq(@case.pascal_case("test123value"), "Test123Value")
 }

--- a/src/path_case_test.mbt
+++ b/src/path_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "path_case basic conversion" {
-  assert_eq(path_case("hello world"), "hello/world")
-  assert_eq(path_case("HelloWorld"), "hello/world")
-  assert_eq(path_case("hello_world"), "hello/world")
-  assert_eq(path_case("hello"), "hello")
+  assert_eq(@case.path_case("hello world"), "hello/world")
+  assert_eq(@case.path_case("HelloWorld"), "hello/world")
+  assert_eq(@case.path_case("hello_world"), "hello/world")
+  assert_eq(@case.path_case("hello"), "hello")
 }
 
 ///|
 test "path_case edge cases" {
-  assert_eq(path_case(""), "")
-  assert_eq(path_case("a"), "a")
-  assert_eq(path_case("A"), "a")
-  assert_eq(path_case("123"), "123")
+  assert_eq(@case.path_case(""), "")
+  assert_eq(@case.path_case("a"), "a")
+  assert_eq(@case.path_case("A"), "a")
+  assert_eq(@case.path_case("123"), "123")
 }
 
 ///|
 test "path_case complex cases" {
-  assert_eq(path_case("XMLHttpRequest"), "xml/http/request")
-  assert_eq(path_case("iPhone-App"), "i/phone/app")
-  assert_eq(path_case("foo bar baz"), "foo/bar/baz")
-  assert_eq(path_case("test123value"), "test/123/value")
+  assert_eq(@case.path_case("XMLHttpRequest"), "xml/http/request")
+  assert_eq(@case.path_case("iPhone-App"), "i/phone/app")
+  assert_eq(@case.path_case("foo bar baz"), "foo/bar/baz")
+  assert_eq(@case.path_case("test123value"), "test/123/value")
 }

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -1,0 +1,44 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "justjavac/case"
+
+// Values
+fn alternating_case(String) -> String
+
+fn camel_case(String) -> String
+
+fn capital_case(String) -> String
+
+fn constant_case(String) -> String
+
+fn dot_case(String) -> String
+
+fn kebab_case(String) -> String
+
+fn no_case(String) -> String
+
+fn pascal_case(String) -> String
+
+fn path_case(String) -> String
+
+fn reverse_case(String) -> String
+
+fn sentence_case(String) -> String
+
+fn snake_case(String) -> String
+
+fn sponge_case(String) -> String
+
+fn swap_case(String) -> String
+
+fn title_case(String) -> String
+
+fn train_case(String) -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/reverse_case_test.mbt
+++ b/src/reverse_case_test.mbt
@@ -1,20 +1,20 @@
 ///|
 test "reverse_case basic conversion" {
-  assert_eq(reverse_case("hello"), "olleh")
-  assert_eq(reverse_case("hello world"), "dlrow olleh")
-  assert_eq(reverse_case("Test123"), "321tseT")
+  assert_eq(@case.reverse_case("hello"), "olleh")
+  assert_eq(@case.reverse_case("hello world"), "dlrow olleh")
+  assert_eq(@case.reverse_case("Test123"), "321tseT")
 }
 
 ///|
 test "reverse_case edge cases" {
-  assert_eq(reverse_case(""), "")
-  assert_eq(reverse_case("a"), "a")
-  assert_eq(reverse_case("ab"), "ba")
+  assert_eq(@case.reverse_case(""), "")
+  assert_eq(@case.reverse_case("a"), "a")
+  assert_eq(@case.reverse_case("ab"), "ba")
 }
 
 ///|
 test "reverse_case with symbols" {
-  assert_eq(reverse_case("hello-world"), "dlrow-olleh")
-  assert_eq(reverse_case("test_case"), "esac_tset")
-  assert_eq(reverse_case("!@#$%"), "%$#@!")
+  assert_eq(@case.reverse_case("hello-world"), "dlrow-olleh")
+  assert_eq(@case.reverse_case("test_case"), "esac_tset")
+  assert_eq(@case.reverse_case("!@#$%"), "%$#@!")
 }

--- a/src/sentence_case_test.mbt
+++ b/src/sentence_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "sentence_case basic conversion" {
-  assert_eq(sentence_case("hello world"), "Hello world")
-  assert_eq(sentence_case("HelloWorld"), "Hello world")
-  assert_eq(sentence_case("hello_world"), "Hello world")
-  assert_eq(sentence_case("hello"), "Hello")
+  assert_eq(@case.sentence_case("hello world"), "Hello world")
+  assert_eq(@case.sentence_case("HelloWorld"), "Hello world")
+  assert_eq(@case.sentence_case("hello_world"), "Hello world")
+  assert_eq(@case.sentence_case("hello"), "Hello")
 }
 
 ///|
 test "sentence_case edge cases" {
-  assert_eq(sentence_case(""), "")
-  assert_eq(sentence_case("a"), "A")
-  assert_eq(sentence_case("A"), "A")
-  assert_eq(sentence_case("123"), "123")
+  assert_eq(@case.sentence_case(""), "")
+  assert_eq(@case.sentence_case("a"), "A")
+  assert_eq(@case.sentence_case("A"), "A")
+  assert_eq(@case.sentence_case("123"), "123")
 }
 
 ///|
 test "sentence_case complex cases" {
-  assert_eq(sentence_case("XMLHttpRequest"), "Xml http request")
-  assert_eq(sentence_case("iPhone-App"), "I phone app")
-  assert_eq(sentence_case("foo bar baz"), "Foo bar baz")
-  assert_eq(sentence_case("test123value"), "Test 123 value")
+  assert_eq(@case.sentence_case("XMLHttpRequest"), "Xml http request")
+  assert_eq(@case.sentence_case("iPhone-App"), "I phone app")
+  assert_eq(@case.sentence_case("foo bar baz"), "Foo bar baz")
+  assert_eq(@case.sentence_case("test123value"), "Test 123 value")
 }

--- a/src/snake_case_test.mbt
+++ b/src/snake_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "snake_case basic conversion" {
-  assert_eq(snake_case("hello world"), "hello_world")
-  assert_eq(snake_case("HelloWorld"), "hello_world")
-  assert_eq(snake_case("hello-world"), "hello_world")
-  assert_eq(snake_case("hello"), "hello")
+  assert_eq(@case.snake_case("hello world"), "hello_world")
+  assert_eq(@case.snake_case("HelloWorld"), "hello_world")
+  assert_eq(@case.snake_case("hello-world"), "hello_world")
+  assert_eq(@case.snake_case("hello"), "hello")
 }
 
 ///|
 test "snake_case edge cases" {
-  assert_eq(snake_case(""), "")
-  assert_eq(snake_case("a"), "a")
-  assert_eq(snake_case("A"), "a")
-  assert_eq(snake_case("123"), "123")
+  assert_eq(@case.snake_case(""), "")
+  assert_eq(@case.snake_case("a"), "a")
+  assert_eq(@case.snake_case("A"), "a")
+  assert_eq(@case.snake_case("123"), "123")
 }
 
 ///|
 test "snake_case complex cases" {
-  assert_eq(snake_case("XMLHttpRequest"), "xml_http_request")
-  assert_eq(snake_case("iPhone-App"), "i_phone_app")
-  assert_eq(snake_case("foo bar baz"), "foo_bar_baz")
-  assert_eq(snake_case("test123value"), "test_123_value")
+  assert_eq(@case.snake_case("XMLHttpRequest"), "xml_http_request")
+  assert_eq(@case.snake_case("iPhone-App"), "i_phone_app")
+  assert_eq(@case.snake_case("foo bar baz"), "foo_bar_baz")
+  assert_eq(@case.snake_case("test123value"), "test_123_value")
 }

--- a/src/sponge_case_test.mbt
+++ b/src/sponge_case_test.mbt
@@ -1,22 +1,22 @@
 ///|
 test "sponge_case basic conversion" {
-  assert_eq(sponge_case("hello world"), "hElLo WoRlD")
-  assert_eq(sponge_case("test string"), "tEsT sTrInG")
-  assert_eq(sponge_case("hello"), "hElLo")
+  assert_eq(@case.sponge_case("hello world"), "hElLo WoRlD")
+  assert_eq(@case.sponge_case("test string"), "tEsT sTrInG")
+  assert_eq(@case.sponge_case("hello"), "hElLo")
 }
 
 ///|
 test "sponge_case edge cases" {
-  assert_eq(sponge_case(""), "")
-  assert_eq(sponge_case("123"), "123")
-  assert_eq(sponge_case("!@#"), "!@#")
-  assert_eq(sponge_case("a"), "a")
-  assert_eq(sponge_case("ab"), "aB")
+  assert_eq(@case.sponge_case(""), "")
+  assert_eq(@case.sponge_case("123"), "123")
+  assert_eq(@case.sponge_case("!@#"), "!@#")
+  assert_eq(@case.sponge_case("a"), "a")
+  assert_eq(@case.sponge_case("ab"), "aB")
 }
 
 ///|
 test "sponge_case with mixed content" {
-  assert_eq(sponge_case("test123value"), "tEsT123vAlUe")
-  assert_eq(sponge_case("hello-world"), "hElLo-WoRlD")
-  assert_eq(sponge_case("a1b2c3"), "a1B2c3")
+  assert_eq(@case.sponge_case("test123value"), "tEsT123vAlUe")
+  assert_eq(@case.sponge_case("hello-world"), "hElLo-WoRlD")
+  assert_eq(@case.sponge_case("a1b2c3"), "a1B2c3")
 }

--- a/src/swap_case_test.mbt
+++ b/src/swap_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "swap_case basic conversion" {
-  assert_eq(swap_case("Hello World"), "hELLO wORLD")
-  assert_eq(swap_case("hELLO wORLD"), "Hello World")
-  assert_eq(swap_case("Test123"), "tEST123")
-  assert_eq(swap_case("hello"), "HELLO")
+  assert_eq(@case.swap_case("Hello World"), "hELLO wORLD")
+  assert_eq(@case.swap_case("hELLO wORLD"), "Hello World")
+  assert_eq(@case.swap_case("Test123"), "tEST123")
+  assert_eq(@case.swap_case("hello"), "HELLO")
 }
 
 ///|
 test "swap_case edge cases" {
-  assert_eq(swap_case(""), "")
-  assert_eq(swap_case("123"), "123")
-  assert_eq(swap_case("!@#"), "!@#")
-  assert_eq(swap_case("A"), "a")
-  assert_eq(swap_case("a"), "A")
+  assert_eq(@case.swap_case(""), "")
+  assert_eq(@case.swap_case("123"), "123")
+  assert_eq(@case.swap_case("!@#"), "!@#")
+  assert_eq(@case.swap_case("A"), "a")
+  assert_eq(@case.swap_case("a"), "A")
 }
 
 ///|
 test "swap_case mixed cases" {
-  assert_eq(swap_case("CamelCase"), "cAMELcASE")
-  assert_eq(swap_case("snake_case"), "SNAKE_CASE")
-  assert_eq(swap_case("kebab-case"), "KEBAB-CASE")
+  assert_eq(@case.swap_case("CamelCase"), "cAMELcASE")
+  assert_eq(@case.swap_case("snake_case"), "SNAKE_CASE")
+  assert_eq(@case.swap_case("kebab-case"), "KEBAB-CASE")
 }

--- a/src/title_case_test.mbt
+++ b/src/title_case_test.mbt
@@ -1,20 +1,20 @@
 ///|
 test "title_case basic conversion" {
-  assert_eq(title_case("the quick brown fox"), "The Quick Brown Fox")
-  assert_eq(title_case("a tale of two cities"), "A Tale of Two Cities")
-  assert_eq(title_case("hello world"), "Hello World")
+  assert_eq(@case.title_case("the quick brown fox"), "The Quick Brown Fox")
+  assert_eq(@case.title_case("a tale of two cities"), "A Tale of Two Cities")
+  assert_eq(@case.title_case("hello world"), "Hello World")
 }
 
 ///|
 test "title_case edge cases" {
-  assert_eq(title_case(""), "")
-  assert_eq(title_case("a"), "A")
-  assert_eq(title_case("the"), "The")
+  assert_eq(@case.title_case(""), "")
+  assert_eq(@case.title_case("a"), "A")
+  assert_eq(@case.title_case("the"), "The")
 }
 
 ///|
 test "title_case with minor words" {
-  assert_eq(title_case("war and peace"), "War and Peace")
-  assert_eq(title_case("the lord of the rings"), "The Lord of the Rings")
-  assert_eq(title_case("to be or not to be"), "To Be or Not to Be")
+  assert_eq(@case.title_case("war and peace"), "War and Peace")
+  assert_eq(@case.title_case("the lord of the rings"), "The Lord of the Rings")
+  assert_eq(@case.title_case("to be or not to be"), "To Be or Not to Be")
 }

--- a/src/train_case_test.mbt
+++ b/src/train_case_test.mbt
@@ -1,23 +1,23 @@
 ///|
 test "train_case basic conversion" {
-  assert_eq(train_case("hello world"), "Hello-World")
-  assert_eq(train_case("HelloWorld"), "Hello-World")
-  assert_eq(train_case("hello_world"), "Hello-World")
-  assert_eq(train_case("hello"), "Hello")
+  assert_eq(@case.train_case("hello world"), "Hello-World")
+  assert_eq(@case.train_case("HelloWorld"), "Hello-World")
+  assert_eq(@case.train_case("hello_world"), "Hello-World")
+  assert_eq(@case.train_case("hello"), "Hello")
 }
 
 ///|
 test "train_case edge cases" {
-  assert_eq(train_case(""), "")
-  assert_eq(train_case("a"), "A")
-  assert_eq(train_case("A"), "A")
-  assert_eq(train_case("123"), "123")
+  assert_eq(@case.train_case(""), "")
+  assert_eq(@case.train_case("a"), "A")
+  assert_eq(@case.train_case("A"), "A")
+  assert_eq(@case.train_case("123"), "123")
 }
 
 ///|
 test "train_case complex cases" {
-  assert_eq(train_case("XMLHttpRequest"), "Xml-Http-Request")
-  assert_eq(train_case("iPhone-App"), "I-Phone-App")
-  assert_eq(train_case("foo bar baz"), "Foo-Bar-Baz")
-  assert_eq(train_case("test123value"), "Test-123-Value")
+  assert_eq(@case.train_case("XMLHttpRequest"), "Xml-Http-Request")
+  assert_eq(@case.train_case("iPhone-App"), "I-Phone-App")
+  assert_eq(@case.train_case("foo bar baz"), "Foo-Bar-Baz")
+  assert_eq(@case.train_case("test123value"), "Test-123-Value")
 }

--- a/src/utils.mbt
+++ b/src/utils.mbt
@@ -216,7 +216,12 @@ fn capitalize(text : String) -> String {
     if chars.length() == 1 {
       first
     } else {
-      first + (try? text[1:]).to_string()
+      // Build the rest of the string from characters
+      let mut rest = ""
+      for i = 1; i < chars.length(); i = i + 1 {
+        rest = rest + chars[i].to_string()
+      }
+      first + rest
     }
   }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Update all test files to use @case.function_name instead of direct function calls
- Fix capitalize function in utils.mbt to properly handle string slicing
- All tests now pass and moon check --deny-warn succeeds

This fixes the 184 test_import_all warnings that were causing moon check --deny-warn to fail.
Each test file now properly references the package functions using the @case prefix
as required for black-box testing in MoonBit.