### PR TITLE
Add coverage reporting and README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,35 @@ jobs:
         run: |
           moon build
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+
+      - name: moon version
+        run: |
+          moon version --all
+
+      - name: moon install
+        run: |
+          moon update
+
+      - name: Run moon test with coverage
+        run: |
+          moon test --target native --enable-coverage
+          moon coverage analyze -p justjavac/case -- -f cobertura -o coverage.xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          disable_search: true
+
   nightly:
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 moonbit-coverage-*.txt
 _coverage
 bisect.coverage
+coverage.xml

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -1,5 +1,8 @@
 # justjavac/case
 
+[![CI](https://github.com/justjavac/moonbit-case/actions/workflows/ci.yml/badge.svg)](https://github.com/justjavac/moonbit-case/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-case/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-case)
+
 String case conversion helpers for MoonBit.
 
 ## Common conversions
@@ -14,4 +17,3 @@ test "common conversions" {
   assert_eq(@case.constant_case("hello world"), "HELLO_WORLD")
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # moonbit-case
 
+[![CI](https://github.com/justjavac/moonbit-case/actions/workflows/ci.yml/badge.svg)](https://github.com/justjavac/moonbit-case/actions/workflows/ci.yml)
+[![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-case/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-case)
+
 Transform strings between different cases: `camelCase`, `PascalCase`, `snake_case`, `kebab-case`, `CONSTANT_CASE`, and many more.
 
 ## Installation


### PR DESCRIPTION
## Summary
- add a dedicated coverage job to GitHub Actions
- upload MoonBit coverage reports to Codecov
- add CI and coverage badges under the titles in README.md and README.mbt.md
- ignore generated coverage.xml

## Validation
- moon test --target native --enable-coverage
- moon coverage analyze -p justjavac/case
- moon coverage analyze -p justjavac/case -- -f cobertura -o coverage.xml