### PR TITLE
feat: add flat, Ada, COBOL, and upper-flat case conversions

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -15,5 +15,9 @@ test "common conversions" {
   assert_eq(@case.snake_case("hello world"), "hello_world")
   assert_eq(@case.kebab_case("hello world"), "hello-world")
   assert_eq(@case.constant_case("hello world"), "HELLO_WORLD")
+  assert_eq(@case.flat_case("hello world"), "helloworld")
+  assert_eq(@case.upper_flat_case("hello world"), "HELLOWORLD")
+  assert_eq(@case.cobol_case("hello world"), "HELLO-WORLD")
+  assert_eq(@case.ada_case("hello world"), "Hello_World")
 }
 ```

--- a/README.md
+++ b/README.md
@@ -3,12 +3,11 @@
 [![CI](https://github.com/justjavac/moonbit-case/actions/workflows/ci.yml/badge.svg)](https://github.com/justjavac/moonbit-case/actions/workflows/ci.yml)
 [![coverage](https://img.shields.io/codecov/c/github/justjavac/moonbit-case/main?label=coverage)](https://codecov.io/gh/justjavac/moonbit-case)
 
-Transform strings between different cases: `camelCase`, `PascalCase`, `snake_case`, `kebab-case`, `CONSTANT_CASE`, and many more.
+Transform strings between different cases: `camelCase`, `PascalCase`, `snake_case`, `kebab-case`, `CONSTANT_CASE`, `flatcase`, `COBOL-CASE`, and more.
 
 ## Installation
 
 ```bash
-moon update
 moon add justjavac/case
 ```
 
@@ -21,6 +20,10 @@ moon add justjavac/case
 @case.snake_case("hello world")       // "hello_world"
 @case.kebab_case("hello world")       // "hello-world"
 @case.constant_case("hello world")    // "HELLO_WORLD"
+@case.flat_case("hello world")        // "helloworld"
+@case.upper_flat_case("hello world")  // "HELLOWORLD"
+@case.cobol_case("hello world")       // "HELLO-WORLD"
+@case.ada_case("hello world")         // "Hello_World"
 
 // Additional transformations
 @case.swap_case("Hello World")        // "hELLO wORLD"

--- a/src/ada_case.mbt
+++ b/src/ada_case.mbt
@@ -1,0 +1,26 @@
+///|
+/// Convert a string to `Ada_Case`.
+///
+/// Each word is capitalized and joined with underscores, which matches naming
+/// styles used in Ada code and some generated identifiers.
+///
+/// # Example
+///
+/// ```mbt check
+/// test "ada_case doc example" {
+///   assert_eq(ada_case("hello world"), "Hello_World")
+///   assert_eq(ada_case("test123value"), "Test_123_Value")
+///   assert_eq(ada_case(""), "")
+/// }
+/// ```
+pub fn ada_case(text : String) -> String {
+  let words = split(text)
+  if words.is_empty() {
+    return ""
+  }
+  let mut result = capitalize(string_to_lower(words[0]))
+  for i = 1; i < words.length(); i = i + 1 {
+    result = result + "_" + capitalize(string_to_lower(words[i]))
+  }
+  result
+}

--- a/src/ada_case_test.mbt
+++ b/src/ada_case_test.mbt
@@ -1,0 +1,23 @@
+///|
+test "ada_case basic conversion" {
+  assert_eq(@case.ada_case("hello world"), "Hello_World")
+  assert_eq(@case.ada_case("hello-world"), "Hello_World")
+  assert_eq(@case.ada_case("HELLO_WORLD"), "Hello_World")
+  assert_eq(@case.ada_case("hello"), "Hello")
+}
+
+///|
+test "ada_case edge cases" {
+  assert_eq(@case.ada_case(""), "")
+  assert_eq(@case.ada_case("a"), "A")
+  assert_eq(@case.ada_case("A"), "A")
+  assert_eq(@case.ada_case("123"), "123")
+}
+
+///|
+test "ada_case complex cases" {
+  assert_eq(@case.ada_case("XMLHttpRequest"), "Xml_Http_Request")
+  assert_eq(@case.ada_case("iPhone-app"), "I_Phone_App")
+  assert_eq(@case.ada_case("foo_bar_baz"), "Foo_Bar_Baz")
+  assert_eq(@case.ada_case("test123value"), "Test_123_Value")
+}

--- a/src/cobol_case.mbt
+++ b/src/cobol_case.mbt
@@ -1,0 +1,26 @@
+///|
+/// Convert a string to `COBOL-CASE`.
+///
+/// This is the uppercased form of `kebab-case`, commonly seen in older
+/// tooling, configuration formats, and integration layers.
+///
+/// # Example
+///
+/// ```mbt check
+/// test "cobol_case doc example" {
+///   assert_eq(cobol_case("hello world"), "HELLO-WORLD")
+///   assert_eq(cobol_case("XMLHttpRequest"), "XML-HTTP-REQUEST")
+///   assert_eq(cobol_case(""), "")
+/// }
+/// ```
+pub fn cobol_case(text : String) -> String {
+  let words = split(text)
+  if words.is_empty() {
+    return ""
+  }
+  let mut result = string_to_upper(words[0])
+  for i = 1; i < words.length(); i = i + 1 {
+    result = result + "-" + string_to_upper(words[i])
+  }
+  result
+}

--- a/src/cobol_case_test.mbt
+++ b/src/cobol_case_test.mbt
@@ -1,0 +1,23 @@
+///|
+test "cobol_case basic conversion" {
+  assert_eq(@case.cobol_case("hello world"), "HELLO-WORLD")
+  assert_eq(@case.cobol_case("HelloWorld"), "HELLO-WORLD")
+  assert_eq(@case.cobol_case("hello_world"), "HELLO-WORLD")
+  assert_eq(@case.cobol_case("hello"), "HELLO")
+}
+
+///|
+test "cobol_case edge cases" {
+  assert_eq(@case.cobol_case(""), "")
+  assert_eq(@case.cobol_case("a"), "A")
+  assert_eq(@case.cobol_case("A"), "A")
+  assert_eq(@case.cobol_case("123"), "123")
+}
+
+///|
+test "cobol_case complex cases" {
+  assert_eq(@case.cobol_case("XMLHttpRequest"), "XML-HTTP-REQUEST")
+  assert_eq(@case.cobol_case("iPhone-App"), "I-PHONE-APP")
+  assert_eq(@case.cobol_case("foo bar baz"), "FOO-BAR-BAZ")
+  assert_eq(@case.cobol_case("test123value"), "TEST-123-VALUE")
+}

--- a/src/flat_case.mbt
+++ b/src/flat_case.mbt
@@ -1,0 +1,26 @@
+///|
+/// Convert a string to `flatcase`.
+///
+/// Lowercased words are joined without separators, which is useful when a
+/// compact identifier should discard original boundaries.
+///
+/// # Example
+///
+/// ```mbt check
+/// test "flat_case doc example" {
+///   assert_eq(flat_case("hello world"), "helloworld")
+///   assert_eq(flat_case("test123value"), "test123value")
+///   assert_eq(flat_case(""), "")
+/// }
+/// ```
+pub fn flat_case(text : String) -> String {
+  let words = split(text)
+  if words.is_empty() {
+    return ""
+  }
+  let mut result = string_to_lower(words[0])
+  for i = 1; i < words.length(); i = i + 1 {
+    result = result + string_to_lower(words[i])
+  }
+  result
+}

--- a/src/flat_case_test.mbt
+++ b/src/flat_case_test.mbt
@@ -1,0 +1,23 @@
+///|
+test "flat_case basic conversion" {
+  assert_eq(@case.flat_case("hello world"), "helloworld")
+  assert_eq(@case.flat_case("HelloWorld"), "helloworld")
+  assert_eq(@case.flat_case("hello_world"), "helloworld")
+  assert_eq(@case.flat_case("hello"), "hello")
+}
+
+///|
+test "flat_case edge cases" {
+  assert_eq(@case.flat_case(""), "")
+  assert_eq(@case.flat_case("a"), "a")
+  assert_eq(@case.flat_case("A"), "a")
+  assert_eq(@case.flat_case("123"), "123")
+}
+
+///|
+test "flat_case complex cases" {
+  assert_eq(@case.flat_case("XMLHttpRequest"), "xmlhttprequest")
+  assert_eq(@case.flat_case("iPhone-App"), "iphoneapp")
+  assert_eq(@case.flat_case("foo bar baz"), "foobarbaz")
+  assert_eq(@case.flat_case("test123value"), "test123value")
+}

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -2,15 +2,21 @@
 package "justjavac/case"
 
 // Values
+pub fn ada_case(String) -> String
+
 pub fn alternating_case(String) -> String
 
 pub fn camel_case(String) -> String
 
 pub fn capital_case(String) -> String
 
+pub fn cobol_case(String) -> String
+
 pub fn constant_case(String) -> String
 
 pub fn dot_case(String) -> String
+
+pub fn flat_case(String) -> String
 
 pub fn kebab_case(String) -> String
 
@@ -33,6 +39,8 @@ pub fn swap_case(String) -> String
 pub fn title_case(String) -> String
 
 pub fn train_case(String) -> String
+
+pub fn upper_flat_case(String) -> String
 
 // Errors
 

--- a/src/upper_flat_case.mbt
+++ b/src/upper_flat_case.mbt
@@ -1,0 +1,26 @@
+///|
+/// Convert a string to `UPPERFLATCASE`.
+///
+/// Uppercased words are joined without separators, which can be useful for
+/// legacy identifiers, short codes, and compact labels.
+///
+/// # Example
+///
+/// ```mbt check
+/// test "upper_flat_case doc example" {
+///   assert_eq(upper_flat_case("hello world"), "HELLOWORLD")
+///   assert_eq(upper_flat_case("iPhone-App"), "IPHONEAPP")
+///   assert_eq(upper_flat_case(""), "")
+/// }
+/// ```
+pub fn upper_flat_case(text : String) -> String {
+  let words = split(text)
+  if words.is_empty() {
+    return ""
+  }
+  let mut result = string_to_upper(words[0])
+  for i = 1; i < words.length(); i = i + 1 {
+    result = result + string_to_upper(words[i])
+  }
+  result
+}

--- a/src/upper_flat_case_test.mbt
+++ b/src/upper_flat_case_test.mbt
@@ -1,0 +1,23 @@
+///|
+test "upper_flat_case basic conversion" {
+  assert_eq(@case.upper_flat_case("hello world"), "HELLOWORLD")
+  assert_eq(@case.upper_flat_case("HelloWorld"), "HELLOWORLD")
+  assert_eq(@case.upper_flat_case("hello_world"), "HELLOWORLD")
+  assert_eq(@case.upper_flat_case("hello"), "HELLO")
+}
+
+///|
+test "upper_flat_case edge cases" {
+  assert_eq(@case.upper_flat_case(""), "")
+  assert_eq(@case.upper_flat_case("a"), "A")
+  assert_eq(@case.upper_flat_case("A"), "A")
+  assert_eq(@case.upper_flat_case("123"), "123")
+}
+
+///|
+test "upper_flat_case complex cases" {
+  assert_eq(@case.upper_flat_case("XMLHttpRequest"), "XMLHTTPREQUEST")
+  assert_eq(@case.upper_flat_case("iPhone-App"), "IPHONEAPP")
+  assert_eq(@case.upper_flat_case("foo bar baz"), "FOOBARBAZ")
+  assert_eq(@case.upper_flat_case("test123value"), "TEST123VALUE")
+}


### PR DESCRIPTION
## Summary
- add `flat_case`, `upper_flat_case`, `cobol_case`, and `ada_case`
- add focused tests for each new conversion style
- update README examples and generated package API docs

## Testing
- `moon fmt`
- `moon check --deny-warn`
- `moon test`
- `moon info --target wasm,wasm-gc,js,native`